### PR TITLE
🩹 fix : 401 에러 exclude=SecurityAutoConfiguration.class 하여 오류 해결

### DIFF
--- a/src/main/java/com/sparta/newsfeed14thfriday/Newsfeed14thfridayApplication.java
+++ b/src/main/java/com/sparta/newsfeed14thfriday/Newsfeed14thfridayApplication.java
@@ -2,8 +2,9 @@ package com.sparta.newsfeed14thfriday;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 public class Newsfeed14thfridayApplication {
 
     public static void main(String[] args) {


### PR DESCRIPTION
@RequestBody로 email, password, username  받고, 성공시 email과 username 반환
email이 이메일 형식이 아니면 오류처리
비밀번호가 8자 이상 영어 대소문자 숫자 특수문자 하나 이상씩 포함하지 않으면 오류처리