### PR TITLE
fix:댓글전체조회에서 response에 deleted속성은 가져오지않도록 변경(사유:삭제된 댓글은삭제되었는지 뜨기때문 일개…

### DIFF
--- a/src/main/java/com/sparta/newsfeed14thfriday/domain/comment/dto/response/CommentDetailResponseDto.java
+++ b/src/main/java/com/sparta/newsfeed14thfriday/domain/comment/dto/response/CommentDetailResponseDto.java
@@ -12,7 +12,6 @@ public class CommentDetailResponseDto {
     private Long commentId;
     private String contents;
     private Long commentLikeCount;
-    private Boolean deleted;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 


### PR DESCRIPTION
…사용자가 삭제되었는지 알필요는없을것같아서,그리고 생성할때 값을 안넣어서 null값으로 나오기때문에)